### PR TITLE
Fix typo in Info.plist

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -68,7 +68,7 @@
 	<key>MinimumOSVersion</key>
 	<string>7.0</string>
 	<key>NSLocationWhenInUseUsageDescription</key>
-	<string>ppsideloaderneeds to know your location to figure out sunrise and sunset times</string>
+	<string>ppsideloader needs to know your location to figure out sunrise and sunset times</string>
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>audio</string>


### PR DESCRIPTION
This likely does nothing for the end user, however it does not change the fact that the lack of a space is not OCD friendly!